### PR TITLE
fix(cnpg-cluster): use backup.secretName

### DIFF
--- a/charts/cnpg-cluster/templates/_helpers.tpl
+++ b/charts/cnpg-cluster/templates/_helpers.tpl
@@ -54,5 +54,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Backup secret name
 */}}
 {{- define "cnpg-cluster.backupSecretName" -}}
-{{ or .Values.secretName (print (include "cnpg-cluster.fullname" .) `-backup`) }}
+{{ or .Values.backup.secretName (print (include "cnpg-cluster.fullname" .) `-backup`) }}
 {{- end }}


### PR DESCRIPTION
The `backup.secretName` was correctly defined in `values.yaml` but not used correctly in the helpers