### PR TITLE
fix(cnpg-cluster): fix PodMonitor

### DIFF
--- a/charts/cnpg-cluster/templates/pooler.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/pooler.cnpg.yaml
@@ -9,9 +9,8 @@ spec:
   cluster:
     name: {{ include "cnpg-cluster.fullname" $ }}
   {{- toYaml $spec | nindent 2 }}
-
-{{- if .Values.monitoring.enablePodMonitor }}
 ---
+{{- if .Values.monitoring.enablePodMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -22,6 +21,7 @@ spec:
       cnpg.io/poolerName: {{ include "cnpg-cluster.fullname" $ }}-{{ $name }}
   podMetricsEndpoints:
   - port: metrics
+---
 {{- end }}
 
 {{- end }}

--- a/charts/cnpg-cluster/templates/pooler.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/pooler.cnpg.yaml
@@ -9,7 +9,6 @@ spec:
   cluster:
     name: {{ include "cnpg-cluster.fullname" $ }}
   {{- toYaml $spec | nindent 2 }}
-{{- end }}
 
 {{- if .Values.monitoring.enablePodMonitor }}
 ---
@@ -23,4 +22,6 @@ spec:
       cnpg.io/poolerName: {{ include "cnpg-cluster.fullname" $ }}-{{ $name }}
   podMetricsEndpoints:
   - port: metrics
+{{- end }}
+
 {{- end }}


### PR DESCRIPTION
A priori la definition du `PodMonitor` doit être dans la boucle (range) des poolers pour que la variable `$name` soit disponible