### PR TITLE
fix(cnpg-cluster): allow customize recovery.externalClusterName

### DIFF
--- a/charts/cnpg-cluster/templates/cluster.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/cluster.cnpg.yaml
@@ -165,7 +165,7 @@ spec:
   bootstrap:
     {{- if .Values.recovery.enabled }}
     recovery:
-      source: cnpg-cluster 
+      source: "{{ or .Values.recovery.externalClusterName "cnpg-cluster" }}"
       {{- if .Values.recovery.targetTime }}
       recoveryTarget:
         targetTime: "{{ .Values.recovery.targetTime }}"
@@ -190,7 +190,7 @@ spec:
 
   {{- if .Values.recovery.enabled }}
   externalClusters:
-    - name: cnpg-cluster
+    - name: "{{ or .Values.recovery.externalClusterName "cnpg-cluster" }}"
       barmanObjectStore:
         {{- toYaml .Values.recovery.backup | nindent 8 }}
   {{- end }}

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -173,3 +173,5 @@ superuserSecretName:
 
 recovery:
   enabled: false
+  # the name of the source cluster in the backups
+  # externalClusterName: source-cluster-name


### PR DESCRIPTION
Looks like restore job use the external cluster name to locate the backup in the `destinationPath`. So we need to be able to customize it if the the cluster name is not `cnpg-cluster`