### PR TITLE
fix(cnpg-cluster): use version 15

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -3,4 +3,4 @@ name: cnpg-cluster
 description: A Helm chart to create cloudnative-pg.io clusters
 type: application
 version: 1.8.1
-appVersion: 14.5-6
+appVersion: 15


### PR DESCRIPTION
this is used as default docker tag but doesnt exist on ghcr 🤔 

```
➜ docker pull ghcr.io/cloudnative-pg/postgis:14.5-6
Error response from daemon: manifest unknown
```
