### PR TITLE
feat: allow simple pg_basebackup

### DIFF
--- a/charts/cnpg-cluster/templates/cluster.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/cluster.cnpg.yaml
@@ -98,6 +98,9 @@ spec:
     {{- else if (and .Values.replica.enabled .Values.replica.source) }}
     pg_basebackup:
       source: {{ .Values.replica.source }}
+    {{- else if (and .Values.pg_basebackup.enabled .Values.pg_basebackup.source) }}
+    pg_basebackup:
+      source: {{ .Values.pg_basebackup.source }}
     {{- else }}
     initdb:
       database: {{ .Values.dbName }}

--- a/charts/cnpg-cluster/templates/cluster.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/cluster.cnpg.yaml
@@ -95,9 +95,6 @@ spec:
       recoveryTarget:
         targetTime: "{{ .Values.recovery.targetTime }}"
       {{- end }}
-    {{- else if (and .Values.replica.enabled .Values.replica.source) }}
-    pg_basebackup:
-      source: {{ .Values.replica.source }}
     {{- else if (and .Values.pg_basebackup.enabled .Values.pg_basebackup.source) }}
     pg_basebackup:
       source: {{ .Values.pg_basebackup.source }}

--- a/charts/cnpg-cluster/tests/__snapshot__/cnpg-cluster_test.yaml.snap
+++ b/charts/cnpg-cluster/tests/__snapshot__/cnpg-cluster_test.yaml.snap
@@ -118,6 +118,19 @@ cluster with enabled backup and recovery:
     cluster:
       name: RELEASE-NAME-cnpg-cluster
     schedule: 1 2 3 * * 0
+cluster with pg_basebackup:
+  1: |
+    - connectionParameters:
+        dbname: app
+        host: some-host-to-replicate-from
+        user: postgres
+      name: source-cluster
+      password:
+        key: password
+        name: source-secret-for-source-replication
+  2: |
+    pg_basebackup:
+      source: source-cluster
 cluster with recovery enabled:
   1: |
     bootstrap:

--- a/charts/cnpg-cluster/tests/cnpg-cluster_test.yaml
+++ b/charts/cnpg-cluster/tests/cnpg-cluster_test.yaml
@@ -103,3 +103,13 @@ tests:
       - template: cluster.cnpg.yaml
         matchSnapshot:
           path: spec.replica
+  - it: cluster with pg_basebackup
+    values:
+      - ./values/pg_basebackup.yaml
+    asserts:
+      - template: cluster.cnpg.yaml
+        matchSnapshot:
+          path: spec.externalClusters
+      - template: cluster.cnpg.yaml
+        matchSnapshot:
+          path: spec.bootstrap

--- a/charts/cnpg-cluster/tests/values/pg_basebackup.yaml
+++ b/charts/cnpg-cluster/tests/values/pg_basebackup.yaml
@@ -1,5 +1,3 @@
-imageName: ghcr.io/cloudnative-pg/postgis:14
-
 pg_basebackup:
   enabled: true
   source: source-cluster

--- a/charts/cnpg-cluster/tests/values/pg_basebackup.yaml
+++ b/charts/cnpg-cluster/tests/values/pg_basebackup.yaml
@@ -1,0 +1,15 @@
+imageName: ghcr.io/cloudnative-pg/postgis:14
+
+pg_basebackup:
+  enabled: true
+  source: source-cluster
+
+externalClusters:
+  - name: source-cluster
+    connectionParameters:
+      host: some-host-to-replicate-from
+      user: postgres
+      dbname: app
+    password:
+      name: source-secret-for-source-replication
+      key: password

--- a/charts/cnpg-cluster/tests/values/replication.yaml
+++ b/charts/cnpg-cluster/tests/values/replication.yaml
@@ -1,5 +1,3 @@
-imageName: ghcr.io/cloudnative-pg/postgis:14
-
 replica:
   enabled: true
   source: source-cluster

--- a/charts/cnpg-cluster/tests/values/replication.yaml
+++ b/charts/cnpg-cluster/tests/values/replication.yaml
@@ -4,6 +4,10 @@ replica:
   enabled: true
   source: source-cluster
 
+pg_basebackup:
+  enabled: true
+  source: source-cluster
+
 externalClusters:
   - name: source-cluster
     connectionParameters:

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -185,3 +185,8 @@ postInitApplicationSQLRefs:
   # secretRefs:
   # - name: post-init-sql-secret
   #   key: secret.sql
+
+#
+pg_basebackup:
+  enabled: false
+  source:


### PR DESCRIPTION
Add `pg_basebackup` values so we can bootstrap cluster from some existing PG : https://cloudnative-pg.io/documentation/1.19/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup