### PR TITLE
fix(cnpg-cluster): add pooler.monitoring.enabledPodMonitor

### DIFF
--- a/charts/cnpg-cluster/templates/pooler.cnpg.yaml
+++ b/charts/cnpg-cluster/templates/pooler.cnpg.yaml
@@ -10,19 +10,6 @@ spec:
   cluster:
     name: {{ include "cnpg-cluster.fullname" $ }}
   {{- toYaml $spec | nindent 2 }}
----
-{{- if $.Values.monitoring.enablePodMonitor }}
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: {{ include "cnpg-cluster.fullname" $ }}-{{ $name }}
-spec:
-  selector:
-    matchLabels:
-      cnpg.io/poolerName: {{ include "cnpg-cluster.fullname" $ }}-{{ $name }}
-  podMetricsEndpoints:
-  - port: metrics
----
-{{- end }}
-
+  monitoring:
+    enablePodMonitor: {{ $.Values.monitoring.enablePodMonitor }}
 {{- end }}

--- a/charts/cnpg-cluster/tests/__snapshot__/cnpg-cluster_test.yaml.snap
+++ b/charts/cnpg-cluster/tests/__snapshot__/cnpg-cluster_test.yaml.snap
@@ -129,23 +129,14 @@ cluster with monitoring:
         app.kubernetes.io/name: cnpg-cluster
         app.kubernetes.io/version: "15"
         cnpg.io/poolerName: RELEASE-NAME-cnpg-cluster-rw
-        helm.sh/chart: cnpg-cluster-1.11.6
+        helm.sh/chart: cnpg-cluster-1.12.0
       name: RELEASE-NAME-cnpg-cluster-rw
     spec:
       cluster:
         name: RELEASE-NAME-cnpg-cluster
       instances: 3
-  2: |
-    apiVersion: monitoring.coreos.com/v1
-    kind: PodMonitor
-    metadata:
-      name: RELEASE-NAME-cnpg-cluster-rw
-    spec:
-      podMetricsEndpoints:
-        - port: metrics
-      selector:
-        matchLabels:
-          cnpg.io/poolerName: RELEASE-NAME-cnpg-cluster-rw
+      monitoring:
+        enablePodMonitor: true
 cluster with pg_basebackup:
   1: |
     - connectionParameters:


### PR DESCRIPTION
> Like for Clusters, a specific Pooler can be monitored using the [Prometheus Operator's](https://github.com/prometheus-operator/prometheus-operator) resource [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/v0.47.1/Documentation/api.md#podmonitor). A PodMonitor correctly pointing to a Pooler can be automatically created by the operator by setting .spec.monitoring.enablePodMonitor to true in the Pooler resource itself (default: false).